### PR TITLE
support chrome 49.0.2623.110

### DIFF
--- a/jquery.uploadFile.js
+++ b/jquery.uploadFile.js
@@ -85,6 +85,8 @@
 						tab_blob.push(files[0].webkitSlice(i, i + j));
 					else if (files[0].mozSlice)
 						tab_blob.push(files[0].mozSlice(i, i + j));
+					else if(files[0].slice){
+                        			tab_blob.push(files[0].slice(i, i + j));
 				}
 				//we initialize our progress bar
 				if (params.progressBar == true)	{


### PR DESCRIPTION
support chrome 49.0.2623.110. because the old version cannot work on chrome 49.0.2623.110, cause of chrome 49.0.2623.110 do not support mozSlice() and webkitSlice() methods.
